### PR TITLE
using alternate video method for iOS webview in Home Assistant app

### DIFF
--- a/web/components/Video.js
+++ b/web/components/Video.js
@@ -1,6 +1,9 @@
 import { html, useEffect, useState } from "../lib/preact.js";
 import { useRoute } from "./hook-router.js";
 
+const agent = navigator.userAgent.toLowerCase();
+const iOSHomeAssistant =  /iphone|ipad|macintosh/.test(agent) && /homeassistant/.test(agent);
+
 const VideoBlob = ({ url }) => {
   const [blobUrl, setBlobUrl] = useState();
 
@@ -48,7 +51,7 @@ const VideoEmbed = ({ url }) => {
 
 export const Video = () => {
   const { getRouteData, back } = useRoute();
-  const [altMode, setAltMode] = useState(false);
+  const [altMode, setAltMode] = useState(iOSHomeAssistant);
 
   return html`<div style=${{
     position: 'fixed',
@@ -79,7 +82,7 @@ export const Video = () => {
       justifyContent: 'center'
     }}>
       <div style="margin: auto; display: flex; gap: 0.5rem;">
-        <button onClick=${() => setAltMode(!altMode)}>Alt mode: ${`${altMode}`}</button>
+        <button onClick=${() => setAltMode(!altMode)}>Mode: ${`${altMode ? 'buffer' : 'stream'}`}</button>
         <button onClick=${() => back()}>Close</button>
       </div>
     </div>

--- a/web/components/Video.js
+++ b/web/components/Video.js
@@ -38,7 +38,7 @@ const VideoBlob = ({ url }) => {
   }, [url]);
 
   if (!blobUrl) {
-    return html`<div>Loading video...</div>`;
+    return html`<div style="line-height: 4; text-align: center;">Loading video...</div>`;
   }
 
   return html`<${VideoEmbed} url=${blobUrl} />`;

--- a/web/components/Video.js
+++ b/web/components/Video.js
@@ -2,6 +2,7 @@ import { html, useEffect, useState } from "../lib/preact.js";
 import { useRoute } from "./hook-router.js";
 
 const agent = navigator.userAgent.toLowerCase();
+// would be great to detect all webviews, but don't know how to do that
 const iOSHomeAssistant =  /iphone|ipad|macintosh/.test(agent) && /homeassistant/.test(agent);
 
 const VideoBlob = ({ url }) => {

--- a/web/lib/persisted-signal.js
+++ b/web/lib/persisted-signal.js
@@ -1,0 +1,14 @@
+import { effect, useSignal } from "./preact.js";
+
+export const usePersistedSignal = (name, defaultValue) => {
+  const key = `catdad.video-gallery/${name}`;
+  const value = localStorage.getItem(key) || defaultValue;
+
+  const signal = useSignal(value);
+
+  effect(() => {
+    localStorage.setItem(key, signal.value);
+  });
+
+  return signal;
+};


### PR DESCRIPTION
Streaming video works in Safari, but doesn't seem to work when embedded into Home Assistant. Users can also pick which video method to use, since I am sure this might affect more than just Home Assistant.